### PR TITLE
Fix #25: Switch nodes/networks widget

### DIFF
--- a/public/encointer-notee.svg
+++ b/public/encointer-notee.svg
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="encointer-notee.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 33.513325 33.513321"
+   height="33.513321mm"
+   width="33.513325mm">
+  <defs
+     id="defs2">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath833">
+      <path
+         d="M 0,0 H 283.465 V 283.465 H 0 Z"
+         id="path831"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath839">
+      <path
+         d="M 61,82 H 226 V 210 H 61 Z"
+         id="path837"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath843">
+      <path
+         d="M 0,0 H 283.465 V 283.465 H 0 Z"
+         id="path841"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath847">
+      <path
+         d="m 117.923,209.071 -24.478,-41.3 21.157,-35.698 c 0.091,0.001 8.566,0.078 8.991,0.132 v 0 c 1.368,0.169 2.661,0.622 3.832,1.588 v 0 c 2.48,2.045 2.762,4.859 2.076,7.7 v 0 c -0.461,1.908 -0.21,3.349 0.992,4.78 v 0 c 0.934,1.115 0.335,2.182 -0.448,3.353 v 0 c 2.264,1.203 2.32,2.961 1.614,5.057 v 0 c -0.575,1.709 -0.218,2.111 1.387,2.65 v 0 c 0.982,0.33 1.959,0.81 2.799,1.424 v 0 c 1.378,1.006 1.709,2.685 0.795,4.159 v 0 c -2.021,3.255 -4.008,6.545 -6.256,9.631 v 0 c -1.49,2.045 -1.954,3.931 -0.763,6.226 v 0 c 1.045,2.016 0.791,4.2 0.212,6.233 v 0 c -1.166,4.11 -2.511,8.17 -3.867,12.22 v 0 c -0.682,2.035 -2.679,6.236 -4.207,8.469 v 0 c -1.409,2.06 -3.481,3.21 -3.793,3.376 v 0 z"
+         id="path845"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath851">
+      <path
+         d="M 0,0 H 284 V 284 H 0 Z"
+         id="path849"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath855">
+      <path
+         d="m 164.324,209.071 c -0.312,-0.166 -2.383,-1.316 -3.794,-3.376 v 0 c -1.527,-2.233 -3.524,-6.434 -4.205,-8.469 v 0 c -1.358,-4.05 -2.701,-8.11 -3.869,-12.22 v 0 c -0.577,-2.033 -0.832,-4.217 0.213,-6.233 v 0 c 1.19,-2.295 0.727,-4.181 -0.763,-6.226 v 0 c -2.249,-3.086 -4.236,-6.376 -6.255,-9.631 v 0 c -0.916,-1.474 -0.584,-3.153 0.794,-4.159 v 0 c 0.84,-0.614 1.817,-1.094 2.799,-1.424 v 0 c 1.604,-0.539 1.962,-0.941 1.387,-2.65 v 0 c -0.706,-2.096 -0.65,-3.854 1.615,-5.057 v 0 c -0.785,-1.171 -1.383,-2.238 -0.448,-3.353 v 0 c 1.201,-1.431 1.451,-2.872 0.991,-4.78 v 0 c -0.685,-2.841 -0.405,-5.655 2.076,-7.7 v 0 c 1.172,-0.966 2.465,-1.419 3.833,-1.588 v 0 c 0.426,-0.054 8.898,-0.131 8.991,-0.132 v 0 l 21.155,35.698 -24.476,41.3 z"
+         id="path853"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath859">
+      <path
+         d="M 0,0 H 284 V 284 H 0 Z"
+         id="path857"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath863">
+      <path
+         d="M 0,0 H 283.465 V 283.465 H 0 Z"
+         id="path861"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath867">
+      <path
+         d="M 0,0 H 284 V 284 H 0 Z"
+         id="path865"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath871">
+      <path
+         d="M 0,0 H 283.465 V 283.465 H 0 Z"
+         id="path869"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:window-maximized="1"
+     inkscape:window-y="57"
+     inkscape:window-x="975"
+     inkscape:window-height="2082"
+     inkscape:window-width="1884"
+     fit-margin-bottom="0"
+     fit-margin-right="0"
+     fit-margin-left="0"
+     fit-margin-top="2.7755576e-17"
+     showgrid="false"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="96.40576"
+     inkscape:cx="41.428473"
+     inkscape:zoom="2.8"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#5f5757"
+     id="base" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-66.349684,-31.202942)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,33.313599,111.30868)"
+       id="g825" />
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,33.313599,111.30868)"
+       id="g835" />
+    <g
+       transform="matrix(0.35277777,0,0,-0.35277777,33.313599,111.30868)"
+       id="g873" />
+    <g
+       style="fill:none;stroke:#323232;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="translate(0,-3.1750678)"
+       id="g1551">
+      <g
+         style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="g929"
+         transform="matrix(0.35277777,0,0,-0.35277777,33.313599,111.30868)">
+        <g
+           style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           clip-path="url(#clipPath847)"
+           id="g927">
+          <g
+             style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             clip-path="url(#clipPath851)"
+             id="g925">
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(113.3987,132.0237)"
+               id="g891">
+              <path
+                 d="m 0,0 c 0.09,0 8.344,0.078 8.759,0.131 1.332,0.17 2.593,0.623 3.733,1.589 2.417,2.045 2.691,4.859 2.023,7.7 -0.449,1.908 -0.204,3.349 0.965,4.78 0.912,1.114 0.329,2.181 -0.436,3.352 2.206,1.204 2.261,2.961 1.573,5.057 -0.56,1.708 -0.212,2.111 1.351,2.65 0.957,0.33 1.909,0.81 2.727,1.425 1.342,1.006 1.665,2.684 0.774,4.159 -1.967,3.254 -3.904,6.545 -6.093,9.63 -1.452,2.046 -1.904,3.932 -0.745,6.226 1.018,2.017 0.77,4.199 0.208,6.234 -1.138,4.11 -2.446,8.17 -3.769,12.219 -0.664,2.036 -2.609,6.237 -4.096,8.469 -1.374,2.061 -3.393,3.21 -3.697,3.376"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path889"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(110.9046,131.2434)"
+               id="g895">
+              <path
+                 d="m 0,0 c 0.071,0.001 4.772,0.407 6.174,0.959 0.554,0.063 1.021,0.155 1.275,0.233 1.121,0.345 2.324,0.784 3.237,1.581 3.175,2.776 2.601,6.124 2.645,8.232 0.027,1.281 0.262,2.744 1.07,4.306 0.531,1.023 0.361,2.037 0.079,3.117 1.171,1.295 1.421,2.832 1.335,4.405 -0.006,0.129 -0.469,1.774 -0.53,1.896 -1.677,3.35 5.437,3.335 -1.752,16.234 -1.979,3.552 -1.64,2.412 0.07,6.276 0.024,0.054 1.279,1.697 -0.337,6.664 -1.28,3.935 -2.076,7.601 -3.448,11.457 -0.723,2.027 -2.461,5.985 -3.78,8.231 -0.046,0.077 -0.092,0.153 -0.138,0.228 -1.18,1.916 -2.771,3.039 -3.032,3.333"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path893"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(108.4104,130.4631)"
+               id="g899">
+              <path
+                 d="m 0,0 c 0.074,0.001 4.768,0.77 5.079,1.829 0.999,0.38 2.978,0.963 3.8,1.998 2.354,2.962 2.86,7.185 3.269,8.763 1.045,4.031 1.327,12.426 1.327,12.426 3.128,9.522 -2.422,16.34 -2.539,18.971 -0.131,2.934 1.479,5.381 1.057,7.336 -0.851,3.922 -2.005,10.582 -3.427,14.245 -0.81,2.087 -2.419,5.988 -3.579,8.218 -0.997,1.917 -2.299,3.093 -2.529,3.522"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path897"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(105.9163,129.6838)"
+               id="g903">
+              <path
+                 d="m 0,0 c 0.065,0 3.729,1.114 3.989,2.678 0.833,0.483 1.608,1.182 2.333,2.202 1.218,1.71 3.168,4.706 4.263,9.31 0.713,3.001 1.055,8.285 1.307,10.915 1.287,13.418 -3.546,15.282 -1.996,23.738 0.634,3.461 -1.971,13.345 -2.957,16.931 -0.608,2.213 -1.579,5.857 -2.57,8.094 -0.815,1.838 -2.127,3.034 -2.32,3.594"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path901"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(103.4221,128.9035)"
+               id="g907">
+              <path
+                 d="M 0,0 C 0.058,0.001 2.69,1.46 2.899,3.526 3.565,4.115 4.221,4.87 4.766,5.934 12.337,20.693 10.012,33.246 9.738,34.137 8.937,36.751 6.159,62.294 5.562,65.982 5.186,68.307 4.318,71.703 3.501,73.95 2.862,75.706 1.797,76.926 1.639,77.617"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path905"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(100.928,128.1233)"
+               id="g911">
+              <path
+                 d="M 0,0 C 0.05,0.001 2.151,1.806 2.309,4.376 2.809,5.069 3.265,5.923 3.71,6.987 4.583,9.078 11.529,26.86 5.789,44.172 5.199,45.951 5.46,53.446 5.25,55.283 4.825,58.923 4.623,62.598 4.186,66.19 3.893,68.59 3.269,71.771 2.633,74.033 2.164,75.703 1.351,76.95 1.229,77.772"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path909"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(98.4339,127.344)"
+               id="g915">
+              <path
+                 d="m 0,0 c 0.041,0 1.363,2.151 1.469,5.225 0.334,0.797 7.867,23.674 2.403,39.685 -0.575,1.687 -0.47,3.544 -0.178,5.502 0.257,1.729 0.198,3.543 0.058,5.34 -0.282,3.546 -0.657,7.149 -0.944,10.644 -0.204,2.477 -0.601,5.44 -1.043,7.718 -0.307,1.583 -0.861,2.859 -0.946,3.813"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path913"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(95.9397,126.5637)"
+               id="g919">
+              <path
+                 d="M 0,0 C 0.033,0 0.775,2.514 1.129,6.073 1.22,6.987 1.444,7.981 1.597,9.094 1.881,11.186 5.421,33.13 1.954,45.65 1.5,47.293 1.724,49.129 1.872,51.031 c 0.13,1.681 0.101,3.434 0.032,5.192 -0.139,3.451 -0.33,6.982 -0.473,10.381 -0.108,2.553 -0.298,5.297 -0.535,7.593 -0.153,1.496 -0.438,2.8 -0.486,3.885"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path917"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(94.1956,125.7834)"
+               id="g923">
+              <path
+                 d="m 0,0 c 0.089,0.001 0,35.697 0,35.697 0,0 0.131,28.6 0,42.541"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path921"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+      </g>
+      <g
+         style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="g971"
+         transform="matrix(0.35277777,0,0,-0.35277777,33.313599,111.30868)">
+        <g
+           style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           clip-path="url(#clipPath855)"
+           id="g969">
+          <g
+             style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             clip-path="url(#clipPath859)"
+             id="g967">
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(168.8909,132.0237)"
+               id="g933">
+              <path
+                 d="m 0,0 c -0.09,0 -8.344,0.078 -8.759,0.131 -1.332,0.17 -2.593,0.623 -3.733,1.589 -2.417,2.045 -2.69,4.859 -2.023,7.7 0.45,1.908 0.205,3.349 -0.965,4.78 -0.911,1.114 -0.328,2.181 0.436,3.352 -2.205,1.204 -2.261,2.961 -1.573,5.057 0.56,1.708 0.212,2.111 -1.351,2.65 -0.957,0.33 -1.908,0.81 -2.726,1.425 -1.343,1.006 -1.665,2.684 -0.775,4.159 1.968,3.254 3.905,6.545 6.094,9.63 1.451,2.046 1.904,3.932 0.744,6.226 -1.018,2.017 -0.77,4.199 -0.208,6.234 1.138,4.11 2.446,8.17 3.769,12.219 0.664,2.036 2.609,6.237 4.097,8.469 1.373,2.061 3.392,3.21 3.696,3.376"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path931"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(171.385,131.2434)"
+               id="g937">
+              <path
+                 d="m 0,0 c -0.07,0.001 -4.772,0.407 -6.173,0.959 -0.555,0.063 -1.022,0.155 -1.276,0.233 -1.121,0.345 -2.323,0.784 -3.237,1.581 -3.175,2.776 -2.6,6.124 -2.645,8.232 -0.027,1.281 -0.262,2.744 -1.07,4.306 -0.531,1.023 -0.36,2.037 -0.078,3.117 -1.172,1.295 -1.421,2.832 -1.336,4.405 0.006,0.129 0.469,1.774 0.53,1.896 1.677,3.35 -5.436,3.335 1.752,16.234 1.979,3.552 1.641,2.412 -0.07,6.276 -0.023,0.054 -1.278,1.697 0.337,6.664 1.28,3.935 2.076,7.601 3.448,11.457 0.723,2.027 2.462,5.985 3.78,8.231 0.046,0.077 0.092,0.153 0.138,0.228 1.181,1.916 2.771,3.039 3.033,3.333"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path935"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(173.8792,130.4631)"
+               id="g941">
+              <path
+                 d="m 0,0 c -0.073,0.001 -4.767,0.77 -5.079,1.829 -0.999,0.38 -2.978,0.963 -3.8,1.998 -2.353,2.962 -2.859,7.185 -3.268,8.763 -1.046,4.031 -1.328,12.426 -1.328,12.426 -3.128,9.522 2.422,16.34 2.539,18.971 0.131,2.934 -1.479,5.381 -1.057,7.336 0.852,3.922 2.005,10.582 3.427,14.245 0.81,2.087 2.419,5.988 3.58,8.218 0.997,1.917 2.298,3.093 2.528,3.522"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path939"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(176.3733,129.6838)"
+               id="g945">
+              <path
+                 d="m 0,0 c -0.065,0 -3.729,1.114 -3.988,2.678 -0.833,0.483 -1.608,1.182 -2.334,2.202 -1.218,1.71 -3.168,4.706 -4.262,9.31 -0.714,3.001 -1.055,8.285 -1.308,10.915 -1.287,13.418 3.547,15.282 1.996,23.738 -0.633,3.461 1.972,13.345 2.957,16.931 0.608,2.213 1.579,5.857 2.571,8.094 0.814,1.838 2.126,3.034 2.32,3.594"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path943"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(178.8675,128.9035)"
+               id="g949">
+              <path
+                 d="m 0,0 c -0.058,0.001 -2.689,1.46 -2.898,3.526 -0.667,0.589 -1.323,1.344 -1.868,2.408 -7.57,14.759 -5.245,27.312 -4.972,28.203 0.802,2.614 3.579,28.157 4.176,31.845 0.376,2.325 1.244,5.721 2.061,7.968 0.639,1.756 1.705,2.976 1.862,3.667"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path947"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(181.3616,128.1233)"
+               id="g953">
+              <path
+                 d="m 0,0 c -0.049,0.001 -2.151,1.806 -2.309,4.376 -0.5,0.693 -0.956,1.547 -1.4,2.611 -0.873,2.091 -7.819,19.873 -2.08,37.185 0.591,1.779 0.329,9.274 0.54,11.111 0.424,3.64 0.626,7.315 1.064,10.907 0.293,2.4 0.917,5.581 1.552,7.843 0.47,1.67 1.283,2.917 1.404,3.739"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path951"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(183.8557,127.344)"
+               id="g957">
+              <path
+                 d="m 0,0 c -0.041,0 -1.363,2.151 -1.469,5.225 -0.333,0.797 -7.866,23.674 -2.402,39.685 0.575,1.687 0.47,3.544 0.177,5.502 -0.257,1.729 -0.197,3.543 -0.058,5.34 0.282,3.546 0.657,7.149 0.944,10.644 0.204,2.477 0.601,5.44 1.043,7.718 0.308,1.583 0.862,2.859 0.946,3.813"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path955"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(186.3499,126.5637)"
+               id="g961">
+              <path
+                 d="m 0,0 c -0.033,0 -0.774,2.514 -1.129,6.073 -0.091,0.914 -0.315,1.908 -0.467,3.021 -0.285,2.092 -3.825,24.036 -0.358,36.556 0.455,1.643 0.23,3.479 0.083,5.381 -0.131,1.681 -0.102,3.434 -0.032,5.192 0.138,3.451 0.33,6.982 0.472,10.381 0.108,2.553 0.299,5.297 0.535,7.593 0.153,1.496 0.439,2.8 0.487,3.885"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path959"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="translate(188.094,125.7834)"
+               id="g965">
+              <path
+                 d="m 0,0 c -0.089,0.001 0,35.697 0,35.697 0,0 -0.131,28.6 0,42.541"
+                 style="fill:none;stroke:#323232;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                 id="path963"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/public/encointer-teeproxy.svg
+++ b/public/encointer-teeproxy.svg
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="33.513325mm"
+   height="33.513321mm"
+   viewBox="0 0 33.513325 33.513321"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="encointer-teeproxy.svg">
+  <defs
+     id="defs2">
+    <clipPath
+       id="clipPath833"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path831"
+         d="M 0,0 H 283.465 V 283.465 H 0 Z" />
+    </clipPath>
+    <clipPath
+       id="clipPath839"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path837"
+         d="M 61,82 H 226 V 210 H 61 Z" />
+    </clipPath>
+    <clipPath
+       id="clipPath843"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path841"
+         d="M 0,0 H 283.465 V 283.465 H 0 Z" />
+    </clipPath>
+    <clipPath
+       id="clipPath847"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path845"
+         d="m 117.923,209.071 -24.478,-41.3 21.157,-35.698 c 0.091,0.001 8.566,0.078 8.991,0.132 v 0 c 1.368,0.169 2.661,0.622 3.832,1.588 v 0 c 2.48,2.045 2.762,4.859 2.076,7.7 v 0 c -0.461,1.908 -0.21,3.349 0.992,4.78 v 0 c 0.934,1.115 0.335,2.182 -0.448,3.353 v 0 c 2.264,1.203 2.32,2.961 1.614,5.057 v 0 c -0.575,1.709 -0.218,2.111 1.387,2.65 v 0 c 0.982,0.33 1.959,0.81 2.799,1.424 v 0 c 1.378,1.006 1.709,2.685 0.795,4.159 v 0 c -2.021,3.255 -4.008,6.545 -6.256,9.631 v 0 c -1.49,2.045 -1.954,3.931 -0.763,6.226 v 0 c 1.045,2.016 0.791,4.2 0.212,6.233 v 0 c -1.166,4.11 -2.511,8.17 -3.867,12.22 v 0 c -0.682,2.035 -2.679,6.236 -4.207,8.469 v 0 c -1.409,2.06 -3.481,3.21 -3.793,3.376 v 0 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath851"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path849"
+         d="M 0,0 H 284 V 284 H 0 Z" />
+    </clipPath>
+    <clipPath
+       id="clipPath855"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path853"
+         d="m 164.324,209.071 c -0.312,-0.166 -2.383,-1.316 -3.794,-3.376 v 0 c -1.527,-2.233 -3.524,-6.434 -4.205,-8.469 v 0 c -1.358,-4.05 -2.701,-8.11 -3.869,-12.22 v 0 c -0.577,-2.033 -0.832,-4.217 0.213,-6.233 v 0 c 1.19,-2.295 0.727,-4.181 -0.763,-6.226 v 0 c -2.249,-3.086 -4.236,-6.376 -6.255,-9.631 v 0 c -0.916,-1.474 -0.584,-3.153 0.794,-4.159 v 0 c 0.84,-0.614 1.817,-1.094 2.799,-1.424 v 0 c 1.604,-0.539 1.962,-0.941 1.387,-2.65 v 0 c -0.706,-2.096 -0.65,-3.854 1.615,-5.057 v 0 c -0.785,-1.171 -1.383,-2.238 -0.448,-3.353 v 0 c 1.201,-1.431 1.451,-2.872 0.991,-4.78 v 0 c -0.685,-2.841 -0.405,-5.655 2.076,-7.7 v 0 c 1.172,-0.966 2.465,-1.419 3.833,-1.588 v 0 c 0.426,-0.054 8.898,-0.131 8.991,-0.132 v 0 l 21.155,35.698 -24.476,41.3 z" />
+    </clipPath>
+    <clipPath
+       id="clipPath859"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path857"
+         d="M 0,0 H 284 V 284 H 0 Z" />
+    </clipPath>
+    <clipPath
+       id="clipPath863"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path861"
+         d="M 0,0 H 283.465 V 283.465 H 0 Z" />
+    </clipPath>
+    <clipPath
+       id="clipPath867"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path865"
+         d="M 0,0 H 284 V 284 H 0 Z" />
+    </clipPath>
+    <clipPath
+       id="clipPath871"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path869"
+         d="M 0,0 H 283.465 V 283.465 H 0 Z" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#716969"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.959798"
+     inkscape:cx="-32.751741"
+     inkscape:cy="68.462665"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="2.7755576e-17"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1110"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-66.349684,-31.202942)">
+    <g
+       id="g825"
+       transform="matrix(0.35277777,0,0,-0.35277777,33.313599,111.30868)" />
+    <g
+       id="g835"
+       transform="matrix(0.35277777,0,0,-0.35277777,33.313599,111.30868)" />
+    <g
+       id="g873"
+       transform="matrix(0.35277777,0,0,-0.35277777,33.313599,111.30868)" />
+    <g
+       id="g1551"
+       transform="translate(0,-3.1750678)"
+       style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none">
+      <g
+         transform="matrix(0.35277777,0,0,-0.35277777,33.313599,111.30868)"
+         id="g929"
+         style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+        <g
+           id="g927"
+           clip-path="url(#clipPath847)"
+           style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+          <g
+             id="g925"
+             clip-path="url(#clipPath851)"
+             style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+            <g
+               id="g891"
+               transform="translate(113.3987,132.0237)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path889"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c 0.09,0 8.344,0.078 8.759,0.131 1.332,0.17 2.593,0.623 3.733,1.589 2.417,2.045 2.691,4.859 2.023,7.7 -0.449,1.908 -0.204,3.349 0.965,4.78 0.912,1.114 0.329,2.181 -0.436,3.352 2.206,1.204 2.261,2.961 1.573,5.057 -0.56,1.708 -0.212,2.111 1.351,2.65 0.957,0.33 1.909,0.81 2.727,1.425 1.342,1.006 1.665,2.684 0.774,4.159 -1.967,3.254 -3.904,6.545 -6.093,9.63 -1.452,2.046 -1.904,3.932 -0.745,6.226 1.018,2.017 0.77,4.199 0.208,6.234 -1.138,4.11 -2.446,8.17 -3.769,12.219 -0.664,2.036 -2.609,6.237 -4.096,8.469 -1.374,2.061 -3.393,3.21 -3.697,3.376" />
+            </g>
+            <g
+               id="g895"
+               transform="translate(110.9046,131.2434)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path893"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c 0.071,0.001 4.772,0.407 6.174,0.959 0.554,0.063 1.021,0.155 1.275,0.233 1.121,0.345 2.324,0.784 3.237,1.581 3.175,2.776 2.601,6.124 2.645,8.232 0.027,1.281 0.262,2.744 1.07,4.306 0.531,1.023 0.361,2.037 0.079,3.117 1.171,1.295 1.421,2.832 1.335,4.405 -0.006,0.129 -0.469,1.774 -0.53,1.896 -1.677,3.35 5.437,3.335 -1.752,16.234 -1.979,3.552 -1.64,2.412 0.07,6.276 0.024,0.054 1.279,1.697 -0.337,6.664 -1.28,3.935 -2.076,7.601 -3.448,11.457 -0.723,2.027 -2.461,5.985 -3.78,8.231 -0.046,0.077 -0.092,0.153 -0.138,0.228 -1.18,1.916 -2.771,3.039 -3.032,3.333" />
+            </g>
+            <g
+               id="g899"
+               transform="translate(108.4104,130.4631)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path897"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c 0.074,0.001 4.768,0.77 5.079,1.829 0.999,0.38 2.978,0.963 3.8,1.998 2.354,2.962 2.86,7.185 3.269,8.763 1.045,4.031 1.327,12.426 1.327,12.426 3.128,9.522 -2.422,16.34 -2.539,18.971 -0.131,2.934 1.479,5.381 1.057,7.336 -0.851,3.922 -2.005,10.582 -3.427,14.245 -0.81,2.087 -2.419,5.988 -3.579,8.218 -0.997,1.917 -2.299,3.093 -2.529,3.522" />
+            </g>
+            <g
+               id="g903"
+               transform="translate(105.9163,129.6838)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path901"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c 0.065,0 3.729,1.114 3.989,2.678 0.833,0.483 1.608,1.182 2.333,2.202 1.218,1.71 3.168,4.706 4.263,9.31 0.713,3.001 1.055,8.285 1.307,10.915 1.287,13.418 -3.546,15.282 -1.996,23.738 0.634,3.461 -1.971,13.345 -2.957,16.931 -0.608,2.213 -1.579,5.857 -2.57,8.094 -0.815,1.838 -2.127,3.034 -2.32,3.594" />
+            </g>
+            <g
+               id="g907"
+               transform="translate(103.4221,128.9035)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path905"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="M 0,0 C 0.058,0.001 2.69,1.46 2.899,3.526 3.565,4.115 4.221,4.87 4.766,5.934 12.337,20.693 10.012,33.246 9.738,34.137 8.937,36.751 6.159,62.294 5.562,65.982 5.186,68.307 4.318,71.703 3.501,73.95 2.862,75.706 1.797,76.926 1.639,77.617" />
+            </g>
+            <g
+               id="g911"
+               transform="translate(100.928,128.1233)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path909"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="M 0,0 C 0.05,0.001 2.151,1.806 2.309,4.376 2.809,5.069 3.265,5.923 3.71,6.987 4.583,9.078 11.529,26.86 5.789,44.172 5.199,45.951 5.46,53.446 5.25,55.283 4.825,58.923 4.623,62.598 4.186,66.19 3.893,68.59 3.269,71.771 2.633,74.033 2.164,75.703 1.351,76.95 1.229,77.772" />
+            </g>
+            <g
+               id="g915"
+               transform="translate(98.4339,127.344)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path913"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c 0.041,0 1.363,2.151 1.469,5.225 0.334,0.797 7.867,23.674 2.403,39.685 -0.575,1.687 -0.47,3.544 -0.178,5.502 0.257,1.729 0.198,3.543 0.058,5.34 -0.282,3.546 -0.657,7.149 -0.944,10.644 -0.204,2.477 -0.601,5.44 -1.043,7.718 -0.307,1.583 -0.861,2.859 -0.946,3.813" />
+            </g>
+            <g
+               id="g919"
+               transform="translate(95.9397,126.5637)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path917"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="M 0,0 C 0.033,0 0.775,2.514 1.129,6.073 1.22,6.987 1.444,7.981 1.597,9.094 1.881,11.186 5.421,33.13 1.954,45.65 1.5,47.293 1.724,49.129 1.872,51.031 c 0.13,1.681 0.101,3.434 0.032,5.192 -0.139,3.451 -0.33,6.982 -0.473,10.381 -0.108,2.553 -0.298,5.297 -0.535,7.593 -0.153,1.496 -0.438,2.8 -0.486,3.885" />
+            </g>
+            <g
+               id="g923"
+               transform="translate(94.1956,125.7834)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path921"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c 0.089,0.001 0,35.697 0,35.697 0,0 0.131,28.6 0,42.541" />
+            </g>
+          </g>
+        </g>
+      </g>
+      <g
+         transform="matrix(0.35277777,0,0,-0.35277777,33.313599,111.30868)"
+         id="g971"
+         style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+        <g
+           id="g969"
+           clip-path="url(#clipPath855)"
+           style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+          <g
+             id="g967"
+             clip-path="url(#clipPath859)"
+             style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+            <g
+               id="g933"
+               transform="translate(168.8909,132.0237)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path931"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c -0.09,0 -8.344,0.078 -8.759,0.131 -1.332,0.17 -2.593,0.623 -3.733,1.589 -2.417,2.045 -2.69,4.859 -2.023,7.7 0.45,1.908 0.205,3.349 -0.965,4.78 -0.911,1.114 -0.328,2.181 0.436,3.352 -2.205,1.204 -2.261,2.961 -1.573,5.057 0.56,1.708 0.212,2.111 -1.351,2.65 -0.957,0.33 -1.908,0.81 -2.726,1.425 -1.343,1.006 -1.665,2.684 -0.775,4.159 1.968,3.254 3.905,6.545 6.094,9.63 1.451,2.046 1.904,3.932 0.744,6.226 -1.018,2.017 -0.77,4.199 -0.208,6.234 1.138,4.11 2.446,8.17 3.769,12.219 0.664,2.036 2.609,6.237 4.097,8.469 1.373,2.061 3.392,3.21 3.696,3.376" />
+            </g>
+            <g
+               id="g937"
+               transform="translate(171.385,131.2434)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path935"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c -0.07,0.001 -4.772,0.407 -6.173,0.959 -0.555,0.063 -1.022,0.155 -1.276,0.233 -1.121,0.345 -2.323,0.784 -3.237,1.581 -3.175,2.776 -2.6,6.124 -2.645,8.232 -0.027,1.281 -0.262,2.744 -1.07,4.306 -0.531,1.023 -0.36,2.037 -0.078,3.117 -1.172,1.295 -1.421,2.832 -1.336,4.405 0.006,0.129 0.469,1.774 0.53,1.896 1.677,3.35 -5.436,3.335 1.752,16.234 1.979,3.552 1.641,2.412 -0.07,6.276 -0.023,0.054 -1.278,1.697 0.337,6.664 1.28,3.935 2.076,7.601 3.448,11.457 0.723,2.027 2.462,5.985 3.78,8.231 0.046,0.077 0.092,0.153 0.138,0.228 1.181,1.916 2.771,3.039 3.033,3.333" />
+            </g>
+            <g
+               id="g941"
+               transform="translate(173.8792,130.4631)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path939"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c -0.073,0.001 -4.767,0.77 -5.079,1.829 -0.999,0.38 -2.978,0.963 -3.8,1.998 -2.353,2.962 -2.859,7.185 -3.268,8.763 -1.046,4.031 -1.328,12.426 -1.328,12.426 -3.128,9.522 2.422,16.34 2.539,18.971 0.131,2.934 -1.479,5.381 -1.057,7.336 0.852,3.922 2.005,10.582 3.427,14.245 0.81,2.087 2.419,5.988 3.58,8.218 0.997,1.917 2.298,3.093 2.528,3.522" />
+            </g>
+            <g
+               id="g945"
+               transform="translate(176.3733,129.6838)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path943"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c -0.065,0 -3.729,1.114 -3.988,2.678 -0.833,0.483 -1.608,1.182 -2.334,2.202 -1.218,1.71 -3.168,4.706 -4.262,9.31 -0.714,3.001 -1.055,8.285 -1.308,10.915 -1.287,13.418 3.547,15.282 1.996,23.738 -0.633,3.461 1.972,13.345 2.957,16.931 0.608,2.213 1.579,5.857 2.571,8.094 0.814,1.838 2.126,3.034 2.32,3.594" />
+            </g>
+            <g
+               id="g949"
+               transform="translate(178.8675,128.9035)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path947"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c -0.058,0.001 -2.689,1.46 -2.898,3.526 -0.667,0.589 -1.323,1.344 -1.868,2.408 -7.57,14.759 -5.245,27.312 -4.972,28.203 0.802,2.614 3.579,28.157 4.176,31.845 0.376,2.325 1.244,5.721 2.061,7.968 0.639,1.756 1.705,2.976 1.862,3.667" />
+            </g>
+            <g
+               id="g953"
+               transform="translate(181.3616,128.1233)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path951"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c -0.049,0.001 -2.151,1.806 -2.309,4.376 -0.5,0.693 -0.956,1.547 -1.4,2.611 -0.873,2.091 -7.819,19.873 -2.08,37.185 0.591,1.779 0.329,9.274 0.54,11.111 0.424,3.64 0.626,7.315 1.064,10.907 0.293,2.4 0.917,5.581 1.552,7.843 0.47,1.67 1.283,2.917 1.404,3.739" />
+            </g>
+            <g
+               id="g957"
+               transform="translate(183.8557,127.344)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path955"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c -0.041,0 -1.363,2.151 -1.469,5.225 -0.333,0.797 -7.866,23.674 -2.402,39.685 0.575,1.687 0.47,3.544 0.177,5.502 -0.257,1.729 -0.197,3.543 -0.058,5.34 0.282,3.546 0.657,7.149 0.944,10.644 0.204,2.477 0.601,5.44 1.043,7.718 0.308,1.583 0.862,2.859 0.946,3.813" />
+            </g>
+            <g
+               id="g961"
+               transform="translate(186.3499,126.5637)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path959"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c -0.033,0 -0.774,2.514 -1.129,6.073 -0.091,0.914 -0.315,1.908 -0.467,3.021 -0.285,2.092 -3.825,24.036 -0.358,36.556 0.455,1.643 0.23,3.479 0.083,5.381 -0.131,1.681 -0.102,3.434 -0.032,5.192 0.138,3.451 0.33,6.982 0.472,10.381 0.108,2.553 0.299,5.297 0.535,7.593 0.153,1.496 0.439,2.8 0.487,3.885" />
+            </g>
+            <g
+               id="g965"
+               transform="translate(188.094,125.7834)"
+               style="fill:none;stroke:#04c2ff;stroke-opacity:0.99134201;stroke-width:1.41732287;stroke-miterlimit:4;stroke-dasharray:none">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path963"
+                 style="fill:none;stroke:#04c2ff;stroke-width:1.41732287;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99134201"
+                 d="m 0,0 c -0.089,0.001 0,35.697 0,35.697 0,0 -0.131,28.6 0,42.541" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/Map.js
+++ b/src/Map.js
@@ -14,6 +14,7 @@ import MapCeremonyPhases from './map/MapCeremonyPhases';
 import MapNodeInfo from './map/MapNodeInfo';
 import MapControl from './map/MapControl';
 import MapSidebar from './map/MapSidebar';
+import MapNodeSwitchWidget from './map/MapNodeSwitchWidget';
 
 import { CommunitiesClusters } from './map/CommunitiesClusters';
 import { LocationsLayer } from './map/LocationsLayer';
@@ -144,9 +145,9 @@ const setters = ['participants', 'meetups', 'attestations']; // action names for
 export default function Map (props) {
   const { debug } = props;
   const mapRef = useRef();
-  const { api, apiState } = useSubstrate();
+  const { api, apiState, socket } = useSubstrate();
 
-  const [ui, setUI] = useState({ selected: '', loading: true, menu: false });
+  const [ui, setUI] = useState({ selected: '', loading: true, menu: false, nodeSwitch: false });
   const [cids, setCids] = useState([]);
   const [hash, setHash] = useState([]);
   const [data, setData] = useState({});
@@ -460,7 +461,7 @@ export default function Map (props) {
 
   /// Handler for sidebar shows completely
   const handleSidebarShow = sidebarSize =>
-    setUI({ ...ui, sidebarSize, menu: false });
+    setUI({ ...ui, sidebarSize, menu: false, nodeSwitch: false });
 
   /// Show left side menu
   const toggleMenu = () => setUI({
@@ -472,7 +473,12 @@ export default function Map (props) {
 
   /// Close left side menu if clicked
   const handleMapClick = () =>
-    ui.menu && setUI({ ...ui, menu: false });
+    ui.menu && setUI({ ...ui, menu: false, nodeSwitch: false });
+
+  /// Open node switch widget
+  const handleClickNode = () =>
+    !ui.nodeSwitch && setUI({ ...ui, nodeSwitch: true });
+  const handleNodeSwitchClose = () => setUI({ ...ui, nodeSwitch: false });
 
   return (
     <Responsive
@@ -484,6 +490,12 @@ export default function Map (props) {
       <Sidebar.Pushable as={Segment}  className='component-wrapper'>
 
         <MapMenu visible={ui.menu} />
+
+        <MapNodeSwitchWidget
+          socket={socket}
+          visible={ui.nodeSwitch}
+          onClose={handleNodeSwitchClose}
+        />
 
         <MapSidebar
           api={api}
@@ -514,6 +526,7 @@ export default function Map (props) {
           <MapNodeInfo
             api={api}
             apiState={apiState}
+            onClickNode={handleClickNode}
             style={ui.portrait && ui.selected ? { display: 'none' } : {}} />
 
           <MapControl

--- a/src/map/MapNodeInfo.js
+++ b/src/map/MapNodeInfo.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Loader } from 'semantic-ui-react';
+import { Card, Loader, Icon } from 'semantic-ui-react';
 
 const Blocks = React.memo(props => {
   const { api } = props;
@@ -78,7 +78,7 @@ function MapNodeInfoMain (props) {
       apiState === 'READY'
         ? <React.Fragment>
           <Card.Content className='info' onClick={onClickNode}>
-            <Card.Header>{nodeInfo.nodeName}</Card.Header>
+            <Card.Header>{nodeInfo.nodeName} <Icon name='chevron down' /></Card.Header>
             <Card.Meta>{`${nodeInfo.chain || ''} v${nodeInfo.nodeVersion}`}</Card.Meta>
           </Card.Content>
           <Card.Content className='blocks'>

--- a/src/map/MapNodeInfo.js
+++ b/src/map/MapNodeInfo.js
@@ -49,7 +49,7 @@ const CeremonyIndex = React.memo(props => {
 }, _ => true);
 
 function MapNodeInfoMain (props) {
-  const { apiState, api } = props;
+  const { apiState, api, onClickNode } = props;
   const [nodeInfo, setNodeInfo] = useState({});
   const system = api && api.rpc && api.rpc.system;
   const getCurrentCeremonyIndex = api && api.query && api.query.encointerScheduler &&
@@ -77,7 +77,7 @@ function MapNodeInfoMain (props) {
     <Card className='encointer-map-node-info' style={props.style || {}}>{
       apiState === 'READY'
         ? <React.Fragment>
-          <Card.Content className='info'>
+          <Card.Content className='info' onClick={onClickNode}>
             <Card.Header>{nodeInfo.nodeName}</Card.Header>
             <Card.Meta>{`${nodeInfo.chain || ''} v${nodeInfo.nodeVersion}`}</Card.Meta>
           </Card.Content>

--- a/src/map/MapNodeSwitchWidget.js
+++ b/src/map/MapNodeSwitchWidget.js
@@ -1,0 +1,353 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Button, Icon, Input, Sidebar, Radio, Segment } from 'semantic-ui-react';
+
+export const CUSTOM_ENDPOINT_KEY = 'encointer-explorer-custom-endpoints';
+
+function getCustomEndpoints () {
+  try {
+    const storedAsset = localStorage.getItem(CUSTOM_ENDPOINT_KEY);
+
+    if (storedAsset) {
+      return JSON.parse(storedAsset);
+    }
+  } catch (e) {
+    console.error(e);
+    // ignore error
+  }
+
+  return [];
+}
+
+function createOwn () {
+  const items = getCustomEndpoints();
+  return items.map((item) => ({
+    info: 'local',
+    text: 'Custom: '.concat(item),
+    value: item
+  }));
+}
+
+function createEndpoints () {
+  return [
+    {
+      isHeader: true,
+      text: 'Test networks',
+      value: ''
+    },
+    // Hardcode default nodes for now
+    {
+      info: 'encointer',
+      text: 'Gesell',
+      provider: 'Encointer Fundation',
+      value: 'wss://gesell.encointer.org'
+    },
+    {
+      info: 'encointer',
+      text: 'Cantillon',
+      provider: 'Encointer Fundation',
+      value: 'wss://cantillon.encointer.org'
+    },
+    {
+      isDevelopment: true,
+      isHeader: true,
+      text: 'Development',
+      value: ''
+    },
+    {
+      info: 'local',
+      text: 'Local Node (Own, 127.0.0.1:9944)',
+      value: 'ws://127.0.0.1:9944'
+    },
+    ...createOwn()
+  ].filter(({ isDisabled }) => !isDisabled);
+}
+
+function combineEndpoints (endpoints) {
+  return endpoints.reduce((result, e) => {
+    if (e.isHeader) {
+      result.push({ header: e.text, isDevelopment: e.isDevelopment, networks: [] });
+    } else {
+      const name = e.text;
+      const prev = result[result.length - 1];
+      const prov = { name: e.provider ? 'hosted by ' + e.provider : e.value, url: e.value };
+
+      if (prev.networks[prev.networks.length - 1] && name === prev.networks[prev.networks.length - 1].name) {
+        prev.networks[prev.networks.length - 1].providers.push(prov);
+      } else {
+        prev.networks.push({
+          icon: e.info,
+          isChild: e.isChild,
+          name,
+          providers: [prov]
+        });
+      }
+    }
+
+    return result;
+  }, []);
+}
+
+function Url ({ apiUrl, className, label, setApiUrl, url }) {
+  const _setApiUrl = useCallback(
+    () => setApiUrl(url),
+    [setApiUrl, url]
+  );
+
+  return (
+    <Radio
+      className={className}
+      label={label}
+      onChange={_setApiUrl}
+      checked={apiUrl === url}
+    />
+  );
+}
+
+function Network ({ apiUrl, className = '', setApiUrl, value: { icon, isChild, name, providers } }) {
+  const isSelected = useMemo(
+    () => providers.some(({ url }) => url === apiUrl),
+    [apiUrl, providers]
+  );
+
+  const _selectFirst = useCallback(
+    () => setApiUrl(providers[0].url),
+    [providers, setApiUrl]
+  );
+
+  return (
+    <div className={`endpoint-network ${className}${isSelected ? ' isSelected highlight--border' : ''}`}>
+      <div
+        className={`endpoint-section${isChild ? ' isChild' : ''}`}
+        onClick={_selectFirst}
+      >
+        <div className='endpoint-value'>{name}</div>
+      </div>
+      {isSelected && providers.map(({ name, url }): React.ReactNode => (
+        <Url
+          apiUrl={apiUrl}
+          key={url}
+          label={name}
+          setApiUrl={setApiUrl}
+          url={url}
+        />
+      ))}
+    </div>
+  );
+}
+
+function GroupDisplay ({ apiUrl, children, className = '', index, isSelected, setApiUrl, setGroup, value: { header, networks } }) {
+  const _setGroup = useCallback(
+    () => setGroup(isSelected ? -1 : index),
+    [index, isSelected, setGroup]
+  );
+
+  return (
+    <Segment
+      padded
+      className={`${className}${isSelected ? ' isSelected' : ''}`}>
+      <div
+        className='groupHeader'
+        onClick={_setGroup}
+      >
+        <Icon name={isSelected ? 'chevron up' : 'chevron down'} />
+        {header}
+      </div>
+      {isSelected && (
+        <>
+          <div className='group-networks'>
+            {networks.map((network, index): React.ReactNode => (
+              <Network
+                apiUrl={apiUrl}
+                key={index}
+                setApiUrl={setApiUrl}
+                value={network}
+              />
+            ))}
+          </div>
+          {children}
+        </>
+      )}
+    </Segment>
+  );
+}
+
+function isValidUrl (url) {
+  return (
+    // some random length... we probably want to parse via some lib
+    (url.length >= 7) &&
+    // check that it starts with a valid ws identifier
+    (url.startsWith('ws://') || url.startsWith('wss://'))
+  );
+}
+
+export default function Endpoints (props) {
+  const { socket, onClose, visible } = props;
+  const linkOptions = createEndpoints();
+  const [groups, setGroups] = useState(combineEndpoints(linkOptions));
+  const extractUrlState = useCallback((apiUrl, groups) => {
+    let groupIndex = groups.findIndex(({ networks }) =>
+      networks.some(({ providers }) =>
+        providers.some(({ url }) => url === apiUrl)
+      )
+    );
+
+    if (groupIndex === -1) {
+      groupIndex = groups.findIndex(({ isDevelopment }) => isDevelopment);
+    }
+
+    return {
+      apiUrl,
+      groupIndex,
+      hasUrlChanged: socket !== apiUrl,
+      isUrlValid: isValidUrl(apiUrl)
+    };
+  }, [socket]);
+  const [{ apiUrl, groupIndex, hasUrlChanged, isUrlValid }, setApiUrl] = useState(extractUrlState(socket, groups));
+  const [storedCustomEndpoints, setStoredCustomEndpoints] = useState(getCustomEndpoints());
+
+  const isKnownUrl = useMemo(() => {
+    let result = false;
+
+    linkOptions.some((endpoint) => {
+      if (endpoint.value === apiUrl) {
+        result = true;
+
+        return true;
+      }
+
+      return false;
+    });
+
+    return result;
+  }, [apiUrl, linkOptions]);
+
+  const isSavedCustomEndpoint = useMemo(() => {
+    let result = false;
+
+    storedCustomEndpoints.some((endpoint) => {
+      if (endpoint === apiUrl) {
+        result = true;
+
+        return true;
+      }
+
+      return false;
+    });
+
+    return result;
+  }, [apiUrl, storedCustomEndpoints]);
+
+  const _changeGroup = useCallback(
+    (groupIndex) => setApiUrl((state) => ({ ...state, groupIndex })),
+    []
+  );
+
+  const _removeApiEndpoint = () => {
+    if (!isSavedCustomEndpoint) return;
+
+    const newStoredCurstomEndpoints = storedCustomEndpoints.filter((url) => url !== apiUrl);
+
+    try {
+      localStorage.setItem(CUSTOM_ENDPOINT_KEY, JSON.stringify(newStoredCurstomEndpoints));
+      setGroups(combineEndpoints(createEndpoints()));
+      setStoredCustomEndpoints(getCustomEndpoints());
+    } catch (e) {
+      console.error(e);
+      // ignore error
+    }
+  };
+
+  const _setApiUrl = useCallback(
+    (apiUrl) => setApiUrl(extractUrlState(apiUrl, groups)),
+    [extractUrlState, groups]
+  );
+
+  const _onChangeCustom = useCallback(
+    e => {
+      const apiUrl = e.target.value;
+      setApiUrl(extractUrlState(apiUrl, groups));
+    },
+    [extractUrlState, groups]
+  );
+
+  const _onApply = useCallback(
+    () => {
+      window.location.assign(`${window.location.origin}${window.location.pathname}?rpc=${encodeURIComponent(apiUrl)}${window.location.hash}`);
+      onClose();
+    },
+    [apiUrl, onClose]
+  );
+
+  const _saveApiEndpoint = () => {
+    try {
+      localStorage.setItem(CUSTOM_ENDPOINT_KEY, JSON.stringify([...storedCustomEndpoints, apiUrl]));
+      _onApply();
+    } catch (e) {
+      console.error(e);
+      // ignore error
+    }
+  };
+
+  return (
+    <Sidebar
+      visible={visible}
+      as={Segment.Group}
+      className='node-switch-widget'
+      onClose={onClose}
+      position='left'
+      vertical='true'
+      width='wide'
+      animation='overlay'
+    >
+      {groups.map((group, index) => (
+        <GroupDisplay
+          apiUrl={apiUrl}
+          index={index}
+          isSelected={groupIndex === index}
+          key={index}
+          setApiUrl={_setApiUrl}
+          setGroup={_changeGroup}
+          value={group}
+        >
+          {group.isDevelopment && (
+            <div className='endpointCustomWrapper'>
+              <div>Custom endpoint</div>
+
+              <Input
+                className='endpointCustom'
+                error={!isUrlValid}
+                onChange={_onChangeCustom}
+                value={apiUrl}
+                action={
+                  isSavedCustomEndpoint
+                    ? <Button onClick={_removeApiEndpoint}> <Icon name='trash alternate' /></Button>
+                    : <Button onClick={_saveApiEndpoint} > <Icon name='save' /></Button>
+                } />
+            </div>
+          )}
+        </GroupDisplay>
+      ))}
+
+      <Segment textAlign='left' className='node-switch-close'>
+        <Button.Group>
+          <Button
+            content='Close'
+            labelPosition='left'
+            icon='angle left'
+            onClick={onClose}/>
+
+          <Button
+            icon='sync'
+            disabled={!(hasUrlChanged && isUrlValid)}
+            positive={true}
+            labelPosition='left'
+            label={{ as: 'a', basic: true, content: 'Switch' }}
+            onClick={_onApply}
+            fluid
+          />
+        </Button.Group>
+
+      </Segment>
+    </Sidebar>
+  );
+}

--- a/src/map/MapNodeSwitchWidget.js
+++ b/src/map/MapNodeSwitchWidget.js
@@ -38,12 +38,14 @@ function createEndpoints () {
     {
       info: 'encointer',
       text: 'Gesell',
+      icon: 'encointer-notee.svg',
       provider: 'Encointer Fundation',
       value: 'wss://gesell.encointer.org'
     },
     {
       info: 'encointer',
       text: 'Cantillon',
+      icon: 'encointer-teeproxy.svg',
       provider: 'Encointer Fundation',
       value: 'wss://cantillon.encointer.org'
     },
@@ -75,7 +77,7 @@ function combineEndpoints (endpoints) {
         prev.networks[prev.networks.length - 1].providers.push(prov);
       } else {
         prev.networks.push({
-          icon: e.info,
+          icon: e.icon,
           isChild: e.isChild,
           name,
           providers: [prov]
@@ -120,6 +122,7 @@ function Network ({ apiUrl, className = '', setApiUrl, value: { icon, isChild, n
         className={`endpoint-section${isChild ? ' isChild' : ''}`}
         onClick={_selectFirst}
       >
+        {icon ? <img className='endpoint-icon' alt='chain logo' src={'/'.concat(icon)} /> : null}
         <div className='endpoint-value'>{name}</div>
       </div>
       {isSelected && providers.map(({ name, url }): React.ReactNode => (
@@ -129,6 +132,7 @@ function Network ({ apiUrl, className = '', setApiUrl, value: { icon, isChild, n
           label={name}
           setApiUrl={setApiUrl}
           url={url}
+          className='endpoint-address'
         />
       ))}
     </div>
@@ -328,24 +332,23 @@ export default function Endpoints (props) {
         </GroupDisplay>
       ))}
 
-      <Segment textAlign='left' className='node-switch-close'>
-        <Button.Group>
-          <Button
-            content='Close'
-            labelPosition='left'
-            icon='angle left'
-            onClick={onClose}/>
+      <Segment className='node-switch-confirm'>
+        <Button
+          icon='sync'
+          disabled={!(hasUrlChanged && isUrlValid)}
+          positive={true}
+          content="Switch"
+          onClick={_onApply}
+          fluid
+        />
+      </Segment>
 
-          <Button
-            icon='sync'
-            disabled={!(hasUrlChanged && isUrlValid)}
-            positive={true}
-            labelPosition='left'
-            label={{ as: 'a', basic: true, content: 'Switch' }}
-            onClick={_onApply}
-            fluid
-          />
-        </Button.Group>
+      <Segment textAlign='left' className='node-switch-close'>
+        <Button
+          content='Close'
+          labelPosition='left'
+          icon='angle left'
+          onClick={onClose}/>
 
       </Segment>
     </Sidebar>

--- a/src/style.css
+++ b/src/style.css
@@ -30,6 +30,10 @@
     background: transparent;
 }
 
+.node-switch-widget .isSelected> .groupHeader {
+    padding-bottom: 0.5rem;
+}
+
 .node-switch-widget .endpoint-network {
     border-left: 0.25rem solid transparent;
     border-radius: 0.25rem;
@@ -48,8 +52,28 @@
     border-color: rgb(241, 145, 53) !important;
 }
 
+.node-switch-widget .endpoint-section {
+    margin-bottom: .5rem;
+    margin-top: 0.4rem;
+}
+
 .node-switch-widget .endpoint-value {
-    
+    font-size: 1.5rem;
+}
+
+.node-switch-widget .endpoint-icon {
+    height: 50px;
+    margin-right: 1rem;
+    width: 50px;
+    background: #fff;
+    border-radius: 25px;
+    padding: 2px;
+    box-shadow: 0 0 0 1px rgba(105,204,57,0.7);
+}
+
+.node-switch-widget .endpoint-address {
+    margin: .5em 0;
+    padding-left: 1.4em;
 }
 
 .encointer-map .node-switch-widget .endpoint-section {
@@ -111,10 +135,18 @@
     flex-direction: row;
     width: 500px;
     height: 67px;
+    cursor: pointer;
 }
 
 .encointer-map .encointer-map-node-info > div {
     padding: .5em;
+}
+
+.encointer-map .encointer-map-node-info .content .meta {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    width: 100%;
+    white-space: nowrap;
 }
 
 .encointer-map .encointer-map-node-info > .loading {

--- a/src/style.css
+++ b/src/style.css
@@ -23,6 +23,41 @@
 .encointer-map .details-sidebar .message {
     overflow-wrap: break-word;
 }
+.node-switch-widget {
+    background: rgb(245, 243, 241);
+}
+.node-switch-widget > .ui.segment {
+    background: transparent;
+}
+
+.node-switch-widget .endpoint-network {
+    border-left: 0.25rem solid transparent;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    margin: 0 0 0.25rem 0;
+    padding: 0.375rem 0.5rem 0.375rem 1rem;
+    position: relative;
+}
+
+.node-switch-widget .endpoint-network.isSelected,
+.node-switch-widget .endpoint-network:hover {
+    background: #fffefd;
+}
+
+.node-switch-widget .endpoint-network.highlight--border {
+    border-color: rgb(241, 145, 53) !important;
+}
+
+.node-switch-widget .endpoint-value {
+    
+}
+
+.encointer-map .node-switch-widget .endpoint-section {
+    align-items: center;
+    display: flex;
+    justify-content: flex-start;
+    position: relative;
+}
 
 .encointer-map-wrapper {
     overflow: hidden !important;


### PR DESCRIPTION
Add ability to switch nodes. On click on node name sidebar on left shown containing hardcoded nodes and also ability to connect to custom node.
Custom node could be saved.

I reuse code from polkadot-js/apps 