### PR TITLE
Fix GA-CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,9 @@
 name: Build and Deploy
 on:
   push:
-    branches:
-      - master
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build-and-deploy:
@@ -14,18 +15,18 @@ jobs:
           persist-credentials: false
 
       - name: Install #This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
-        uses: borales/actions-yarn@v2.0.0
+        uses: borales/actions-yarn@v2.3.0
         with:
           cmd: install # will run `yarn install` command
-      - name: Build	
-        uses: borales/actions-yarn@v2.0.0
+      - name: Build
+        uses: borales/actions-yarn@v2.3.0
         with: # will run `yarn build` command
           cmd: |
             build
             cp ./config/CNAME ./build/CNAME
-      - name: Deploy 🚀
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: ./build
+#      - name: Deploy 🚀
+#        uses: peaceiris/actions-gh-pages@v3
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          publish_branch: gh-pages
+#          publish_dir: ./build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: Build and Deploy
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build-and-deploy:
@@ -24,9 +22,9 @@ jobs:
           cmd: |
             build
             cp ./config/CNAME ./build/CNAME
-#      - name: Deploy 🚀
-#        uses: peaceiris/actions-gh-pages@v3
-#        with:
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          publish_branch: gh-pages
-#          publish_dir: ./build
+      - name: Deploy 🚀
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./build


### PR DESCRIPTION
After merging https://github.com/encointer/explorer/pull/42 our CI failed. According to https://github.com/Borales/actions-yarn/issues/15, this can happen if dependencies are fetched from git directly.

This should be fixed with a simple uprate of the yarn action.

Edit: Tested the fix. It worked.

We should update the CI to have two jobs.
* Build: run on PR.
* Deploy: only run on release?

What do you think about this @brenzi ?
