### PR TITLE
[Map] fix block production time

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -187,8 +187,9 @@ export default function Map (props) {
 
     debug && console.log('FETCHING LOCATIONS AND PROPERTIES');
 
-    // blockProductionTime = minimumPeriod * 2 as long as we use aura.
-    const blockProductionTime = constants.timestamp.minimumPeriod * 2 / 1_000;
+    // Block production time in seconds.
+    // Since async backing, all our chains run on 6 seconds.
+    const blockProductionTime = 6;
 
     debug && console.log(`Timestamp.minimumPeriod: ${constants.timestamp.minimumPeriod}`);
     debug && console.log(`BlockProductionTime: ${blockProductionTime}`);


### PR DESCRIPTION
We were still using the timestamp pallet to infer the block production time. However, this value is no longer correct since async backing for our parachains.